### PR TITLE
Fixes Legend Engine URL path

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -19,7 +19,7 @@ LEGEND_GITLAB_RELATION_NAME = "legend-engine-gitlab"
 LEGEND_STUDIO_RELATION_NAME = "legend-engine"
 
 ENGINE_CONFIG_FILE_CONTAINER_LOCAL_PATH = "/engine-config.json"
-ENGINE_SERVICE_URL_FORMAT = "%(schema)s://%(host)s:%(port)s%(path)s"
+ENGINE_SERVICE_URL_FORMAT = "%(schema)s://%(host)s:%(port)s"
 ENGINE_GITLAB_REDIRECT_URI_FORMAT = "%(base_url)s/callback"
 
 TRUSTSTORE_PASSPHRASE = "Legend Engine"
@@ -27,7 +27,7 @@ TRUSTSTORE_CONTAINER_LOCAL_PATH = "/truststore.jks"
 
 APPLICATION_CONNECTOR_PORT_HTTP = 6060
 APPLICATION_CONNECTOR_PORT_HTTPS = 6066
-APPLICATION_ROOT_PATH = "/api"
+APPLICATION_ROOT_PATH = "/"
 
 APPLICATION_LOGGING_FORMAT = "%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p [%thread] %c - %m%n"
 
@@ -128,7 +128,6 @@ class LegendEngineServerCharm(legend_operator_base.BaseFinosLegendCoreServiceCha
                 "schema": legend_operator_base.APPLICATION_CONNECTOR_TYPE_HTTP,
                 "host": ip_address,
                 "port": APPLICATION_CONNECTOR_PORT_HTTP,
-                "path": APPLICATION_ROOT_PATH,
             }
         )
 

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -4,8 +4,9 @@
 """Module testing the Legend Engine Operator."""
 
 import json
+from unittest import mock
 
-from charms.finos_legend_libs.v0 import legend_operator_testing
+from charms.finos_legend_libs.v0 import legend_operator_base, legend_operator_testing
 from ops import testing as ops_testing
 
 import charm
@@ -73,3 +74,12 @@ class LegendEngineTestCase(legend_operator_testing.TestBaseFinosCoreServiceLegen
             rel.data[self.harness.charm.app],
             {"legend-engine-url": self.harness.charm._get_engine_service_url()},
         )
+
+    @mock.patch.object(legend_operator_base, "get_ip_address")
+    def test_get_legend_gitlab_redirect_uris(self, mock_get_ip_address):
+        self.harness.begin()
+        mock_get_ip_address.return_value = "fake_ip"
+        actual_uris = self.harness.charm._get_legend_gitlab_redirect_uris()
+
+        expected_url = "http://fake_ip:6060/callback"
+        self.assertEqual([expected_url], actual_uris)


### PR DESCRIPTION
The Finos Legend Engine does not contain any ``/api`` paths, and the correct callback path should be ``%(url)s/callback``, not ``%(url)s/api/callback`` (accessing this would result in a 404 Not Found error).