### PR TITLE
Updates Engine service url to a name

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -19,7 +19,7 @@ LEGEND_GITLAB_RELATION_NAME = "legend-engine-gitlab"
 LEGEND_STUDIO_RELATION_NAME = "legend-engine"
 
 ENGINE_CONFIG_FILE_CONTAINER_LOCAL_PATH = "/engine-config.json"
-ENGINE_SERVICE_URL_FORMAT = "%(schema)s://%(host)s:%(port)s"
+ENGINE_SERVICE_URL_FORMAT = "%(schema)s://%(host)s"
 ENGINE_GITLAB_REDIRECT_URI_FORMAT = "%(base_url)s/callback"
 
 TRUSTSTORE_PASSPHRASE = "Legend Engine"
@@ -121,13 +121,12 @@ class LegendEngineServerCharm(legend_operator_base.BaseFinosLegendCoreServiceCha
         return LEGEND_DB_RELATION_NAME
 
     def _get_engine_service_url(self):
-        ip_address = legend_operator_base.get_ip_address()
+        svc_name = self.model.config["external-hostname"] or self.app.name
         return ENGINE_SERVICE_URL_FORMAT % (
             {
                 # NOTE(aznashwan): we always return the plain HTTP endpoint:
                 "schema": legend_operator_base.APPLICATION_CONNECTOR_TYPE_HTTP,
-                "host": ip_address,
-                "port": APPLICATION_CONNECTOR_PORT_HTTP,
+                "host": svc_name,
             }
         )
 

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -4,9 +4,8 @@
 """Module testing the Legend Engine Operator."""
 
 import json
-from unittest import mock
 
-from charms.finos_legend_libs.v0 import legend_operator_base, legend_operator_testing
+from charms.finos_legend_libs.v0 import legend_operator_testing
 from ops import testing as ops_testing
 
 import charm
@@ -75,14 +74,30 @@ class LegendEngineTestCase(legend_operator_testing.TestBaseFinosCoreServiceLegen
             {"legend-engine-url": self.harness.charm._get_engine_service_url()},
         )
 
-    @mock.patch.object(legend_operator_base, "get_ip_address")
-    def test_get_legend_gitlab_redirect_uris(self, mock_get_ip_address):
+    def test_get_legend_gitlab_redirect_uris(self):
         self.harness.begin()
-        mock_get_ip_address.return_value = "fake_ip"
         actual_uris = self.harness.charm._get_legend_gitlab_redirect_uris()
 
-        expected_url = "http://fake_ip:6060/callback"
+        expected_url = "http://%s/callback" % self.harness.charm.app.name
         self.assertEqual([expected_url], actual_uris)
 
     def test_upgrade_charm(self):
         self._test_upgrade_charm()
+
+    def test_get_engine_service_url(self):
+        self.harness.set_leader(True)
+        self.harness.begin_with_initial_hooks()
+
+        # Test without external-hostname config.
+        actual_url = self.harness.charm._get_engine_service_url()
+
+        expected_url = "http://%s" % self.harness.charm.app.name
+        self.assertEqual(expected_url, actual_url)
+
+        # Test with external-hostname config.
+        hostname = "foo.lish"
+        self.harness.update_config({"external-hostname": hostname})
+        actual_url = self.harness.charm._get_engine_service_url()
+
+        expected_url = "http://%s" % hostname
+        self.assertEqual(expected_url, actual_url)


### PR DESCRIPTION
When deploying a Juju Application, a Kubernetes service is spawned bearing the same name as the application. We can use that service name to resolve any addresses between the services. For example, we can use ``http://SDLC_APP_NAME/`` to access Engine, instead of ``http://EPHEMERAL_IP:6060/``.

This way, even if this charm is upgraded or refreshed, we wouldn't have to update Legend Studio with a new service URL.

Alternatively, we can allow users to bring their own host name by using the ``external-hostname`` config option.