### PR TITLE
Fixes the Engine URL for Studio

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -21,6 +21,7 @@ LEGEND_STUDIO_RELATION_NAME = "legend-engine"
 ENGINE_CONFIG_FILE_CONTAINER_LOCAL_PATH = "/engine-config.json"
 ENGINE_SERVICE_URL_FORMAT = "%(schema)s://%(host)s"
 ENGINE_GITLAB_REDIRECT_URI_FORMAT = "%(base_url)s/callback"
+ENGINE_API_FORMAT = "%(base_url)s/api"
 
 TRUSTSTORE_PASSPHRASE = "Legend Engine"
 TRUSTSTORE_CONTAINER_LOCAL_PATH = "/truststore.jks"
@@ -120,7 +121,7 @@ class LegendEngineServerCharm(legend_operator_base.BaseFinosLegendCoreServiceCha
     def _get_legend_db_relation_name(cls):
         return LEGEND_DB_RELATION_NAME
 
-    def _get_engine_service_url(self):
+    def _get_engine_service_base_url(self):
         svc_name = self.model.config["external-hostname"] or self.app.name
         return ENGINE_SERVICE_URL_FORMAT % (
             {
@@ -131,7 +132,7 @@ class LegendEngineServerCharm(legend_operator_base.BaseFinosLegendCoreServiceCha
         )
 
     def _get_legend_gitlab_redirect_uris(self):
-        base_url = self._get_engine_service_url()
+        base_url = self._get_engine_service_base_url()
         redirect_uris = [ENGINE_GITLAB_REDIRECT_URI_FORMAT % {"base_url": base_url}]
         return redirect_uris
 
@@ -220,7 +221,8 @@ class LegendEngineServerCharm(legend_operator_base.BaseFinosLegendCoreServiceCha
 
     def _on_studio_relation_joined(self, event: charm.RelationJoinedEvent) -> None:
         rel = event.relation
-        engine_url = self._get_engine_service_url()
+        base_url = self._get_engine_service_base_url()
+        engine_url = ENGINE_API_FORMAT % {"base_url": base_url}
         logger.info("Providing following Engine URL to Studio: %s", engine_url)
         rel.data[self.app]["legend-engine-url"] = engine_url
 

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -69,9 +69,10 @@ class LegendEngineTestCase(legend_operator_testing.TestBaseFinosCoreServiceLegen
         rel = self.harness.charm.framework.model.get_relation(
             charm.LEGEND_STUDIO_RELATION_NAME, rel_id
         )
+        base_url = self.harness.charm._get_engine_service_base_url()
         self.assertEqual(
             rel.data[self.harness.charm.app],
-            {"legend-engine-url": self.harness.charm._get_engine_service_url()},
+            {"legend-engine-url": "%s/api" % base_url},
         )
 
     def test_get_legend_gitlab_redirect_uris(self):
@@ -84,12 +85,12 @@ class LegendEngineTestCase(legend_operator_testing.TestBaseFinosCoreServiceLegen
     def test_upgrade_charm(self):
         self._test_upgrade_charm()
 
-    def test_get_engine_service_url(self):
+    def test_get_engine_service_base_url(self):
         self.harness.set_leader(True)
         self.harness.begin_with_initial_hooks()
 
         # Test without external-hostname config.
-        actual_url = self.harness.charm._get_engine_service_url()
+        actual_url = self.harness.charm._get_engine_service_base_url()
 
         expected_url = "http://%s" % self.harness.charm.app.name
         self.assertEqual(expected_url, actual_url)
@@ -97,7 +98,7 @@ class LegendEngineTestCase(legend_operator_testing.TestBaseFinosCoreServiceLegen
         # Test with external-hostname config.
         hostname = "foo.lish"
         self.harness.update_config({"external-hostname": hostname})
-        actual_url = self.harness.charm._get_engine_service_url()
+        actual_url = self.harness.charm._get_engine_service_base_url()
 
         expected_url = "http://%s" % hostname
         self.assertEqual(expected_url, actual_url)


### PR DESCRIPTION
Legend Studio will try to access ``hostname/engine/server/v1/currentUser``, however the correct URI should be ``hostname/engine/api/server/v1/currentUser``.

Updates the data written into the Studio relation to the correct URL.

NOTE: The Engine API is exposed under ``/engine/api``, while the gitlab callback is ``/engine/callback``.