### PR TITLE
Adds new configuration options for Legend Engine

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -223,6 +223,9 @@ class LegendEngineServerCharm(legend_operator_base.BaseFinosLegendCoreServiceCha
                 },
             },
             "metadataserver": {"pure": {"host": "127.0.0.1", "port": 8090}},
+            "relationalexecution": {
+                "tempPath": "/tmp/",
+            },
             "vaults": [],
         }
 


### PR DESCRIPTION
Recent FINOS Legend Engine images require a few additional configuration options in order to start properly: ``relationalexecution``.