### PR TITLE
Updates the legend-juju-libs library (cert fix)

### DIFF
--- a/lib/charms/finos_legend_libs/v0/legend_operator_base.py
+++ b/lib/charms/finos_legend_libs/v0/legend_operator_base.py
@@ -25,7 +25,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 6
 
 logger = logging.getLogger(__name__)
 
@@ -793,7 +793,7 @@ class BaseFinosLegendCoreServiceCharm(BaseFinosLegendCharm):
         """Returns an `OpenSSL.X509` instance of the certificate of the related GitLab."""
         gitlab_creds = (
             self._legend_gitlab_consumer.get_legend_gitlab_creds(None))
-        if not gitlab_creds or 'gitlab_host_cert_b64' not in gitlab_creds:
+        if not gitlab_creds or not gitlab_creds.get('gitlab_host_cert_b64'):
             return None
         return parse_base64_certificate(
             gitlab_creds['gitlab_host_cert_b64'])

--- a/lib/charms/finos_legend_libs/v0/legend_operator_testing.py
+++ b/lib/charms/finos_legend_libs/v0/legend_operator_testing.py
@@ -21,7 +21,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 7
 
 
 TEST_CERTIFICATE_BASE64 = """
@@ -558,3 +558,23 @@ class TestBaseFinosCoreServiceLegendCharm(BaseFinosLegendCharmTestCase):
         self.assertNotIsInstance(
             self.harness.charm._get_core_legend_service_configs(db_creds, gitlab_creds),
             model.WaitingStatus)
+
+    @mock.patch.object(legend_operator_base, "parse_base64_certificate")
+    def _test_get_legend_gitlab_certificate(self, mock_parse_cert):
+        self.harness.begin_with_initial_hooks()
+        mock_get_creds = self.patch(
+            self.harness.charm._legend_gitlab_consumer, 'get_legend_gitlab_creds'
+        )
+        # Test with no credentials.
+        mock_get_creds.return_value = None
+        self.assertIsNone(self.harness.charm._get_legend_gitlab_certificate())
+
+        # Test with empty string certificate.
+        mock_get_creds.return_value = {"gitlab_host_cert_b64": ""}
+        self.assertIsNone(self.harness.charm._get_legend_gitlab_certificate())
+
+        # Test with a certificate.
+        mock_get_creds.return_value = {"gitlab_host_cert_b64": "some-cert"}
+        cert = self.harness.charm._get_legend_gitlab_certificate()
+        mock_parse_cert.assert_called_once_with("some-cert")
+        self.assertEqual(cert, mock_parse_cert.return_value)


### PR DESCRIPTION
The new updates include the following:

- If the gitlab integrator charm passes in in the relation data an empty certificate, the Legend Charms will try to parse it, which will fail. This addresses that issue.

Depends-On: https://github.com/finos/legend-juju-libs/pull/14