### PR TITLE
lint: Fixes the lint job

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,11 +34,13 @@ commands =
     isort {[vars]all_path}
     black {[vars]all_path}
 
+# TODO: remove the flake8 constraint after this issue is resolved:
+# https://github.com/csachs/pyproject-flake8/issues/13
 [testenv:lint]
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 < 5.0.0
     flake8-docstrings
     flake8-copyright
     flake8-builtins


### PR DESCRIPTION
flake8 released version 5.0.0. Because of this, ``pyproject-flake8`` is failing because a class it was using from flake8 no longer exists, resulting in the following error:

```
AttributeError: module 'flake8.options.config' has no attribute 'ConfigFileFinder'
```

This commit can be reversed once this issue is resolved: csachs/pyproject-flake8#13