### PR TITLE
Delete unused actions.yaml file

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,8 +1,0 @@
-# Copyright 2021 Canonical
-# See LICENSE file for licensing details.
-
-# TODO(aznashwan): determine if the Engine offers any actions
-# Possible ones may include:
-#   - creating a Gitlab project (or whatever other "bootstrapping actions"
-#     are needed on Gitlab)
-#   - creating a legend "workspace" (i.e. tenant)


### PR DESCRIPTION
The file is empty, and newer versions of charmcraft (>= 2.4.0) has issues with this fact, causing the charm building actions to fail.